### PR TITLE
Handle composed modules when expanding a subworkflow from a class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Add command `nf-class modules create-from-class` [#1](https://github.com/mirpedrol/nf-class/pull/1)
 - Add command `nf-class subworkflows expand-class` [#2](https://github.com/mirpedrol/nf-class/pull/2)
 - Add pytests [#5](https://github.com/mirpedrol/nf-class/pull/5)
+- Handle composed modules when expanding a subworkflow [#6](https://github.com/mirpedrol/nf-class/pull/6)

--- a/nf_class/subworkflows/create.py
+++ b/nf_class/subworkflows/create.py
@@ -275,6 +275,7 @@ class SubworkflowExpandClass(ComponentCreateFromClass):
                         found_input = True
                     if "then" in line:
                         while re.sub(r"\s", "", line) != "}":
+                            line = re.sub(r"process.", "workflow.", line)
                             module_asserts.append(line)
                             line = next(lines)
                         found_test = True

--- a/nf_class/subworkflows/create.py
+++ b/nf_class/subworkflows/create.py
@@ -255,6 +255,9 @@ class SubworkflowExpandClass(ComponentCreateFromClass):
                             if line.strip().startswith("run("):
                                 composed_name = line.split('"')[1].lower()
                                 composed_name = re.sub(r"_", "/", composed_name)
+                                # Add composed module to tags
+                                if composed_name not in self.components_tags:
+                                    self.components_tags += f"""\ttag "{composed_name}"\n"""
                             if line.strip().startswith("script"):
                                 # update path for subworkflow
                                 line_split = line.split('"')
@@ -262,7 +265,6 @@ class SubworkflowExpandClass(ComponentCreateFromClass):
                                     line_split[0]
                                     + f'"../../../../modules/{self.org}/{composed_name}/main.nf"'
                                     + line_split[2]
-                                    + "\n"
                                 )
                             setup_code += line
                             line = next(lines)

--- a/nf_class/subworkflows/create.py
+++ b/nf_class/subworkflows/create.py
@@ -3,10 +3,12 @@ import re
 from pathlib import Path
 from typing import Optional
 
+import questionary
 import yaml
 
 from nf_class.components.create import ComponentCreateFromClass
 from nf_class.utils import NF_CLASS_MODULES_REMOTE
+from nf_core.utils import nfcore_question_style
 
 log = logging.getLogger(__name__)
 
@@ -39,6 +41,18 @@ class SubworkflowExpandClass(ComponentCreateFromClass):
         modules_repo_url: Optional[str] = NF_CLASS_MODULES_REMOTE,
         modules_repo_branch: Optional[str] = "main",
     ):
+        while prefix == "" and suffix == "":
+            log.info("Please provide a prefix or suffix for the subworkflow name.")
+            prefix = questionary.text(
+                "Prefix:",
+                default="",
+                style=nfcore_question_style,
+            ).unsafe_ask()
+            suffix = questionary.text(
+                "Suffix:",
+                default="",
+                style=nfcore_question_style,
+            ).unsafe_ask()
         subworkflow_name = f"{prefix}{'_' if prefix else ''}{classname}{'_' if suffix else ''}{suffix}"
         super().__init__(
             "subworkflows",

--- a/nf_class/subworkflows/create.py
+++ b/nf_class/subworkflows/create.py
@@ -278,6 +278,11 @@ class SubworkflowExpandClass(ComponentCreateFromClass):
                     if "then" in line:
                         while re.sub(r"\s", "", line) != "}":
                             line = re.sub(r"process.", "workflow.", line)
+                            if "match(" in line:
+                                # give a new name to snapshot to avoid duplications
+                                line_split = line.split('"')
+                                channel_name = line.split("workflow.out.")[1].split(")")[0]
+                                line = line_split[0] + f'"{component.replace("/", "_")}_{channel_name}"' + line_split[2]
                             module_asserts.append(line)
                             line = next(lines)
                         found_test = True


### PR DESCRIPTION
Handle composed modules when expanding a subworkflow from a class
Also require a prefix or suffix for the subworkflow name. This is to avoid using the classname for both the subworkflow and all imported modules.