### PR TITLE
Safe fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,5 @@
 - Add command `nf-class subworkflows expand-class` [#2](https://github.com/mirpedrol/nf-class/pull/2)
 - Add pytests [#5](https://github.com/mirpedrol/nf-class/pull/5)
 - Handle composed modules when expanding a subworkflow [#6](https://github.com/mirpedrol/nf-class/pull/6)
-- Modify expand-class command to avoid conditional includes [#8](https://github.com/mirpedrol/nf-class/pull/8)
+- Modify `expand-class` command to avoid conditional includes [#8](https://github.com/mirpedrol/nf-class/pull/8)
+- Don't allow expanding a subworkflow in a pipelines repo [#10](https://github.com/mirpedrol/nf-class/pull/10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,4 @@
 - Add pytests [#5](https://github.com/mirpedrol/nf-class/pull/5)
 - Handle composed modules when expanding a subworkflow [#6](https://github.com/mirpedrol/nf-class/pull/6)
 - Modify `expand-class` command to avoid conditional includes [#8](https://github.com/mirpedrol/nf-class/pull/8)
-- Don't allow expanding a subworkflow in a pipelines repo [#10](https://github.com/mirpedrol/nf-class/pull/10)
+- Don't allow expanding a subworkflow in a pipelines repo & pin nf-core version [#10](https://github.com/mirpedrol/nf-class/pull/10)

--- a/nf_class/subworkflows/create.py
+++ b/nf_class/subworkflows/create.py
@@ -71,6 +71,9 @@ class SubworkflowExpandClass(ComponentCreateFromClass):
 
     def expand_class(self):
         """Expand the subworkflow with modules from a class."""
+        if self.repo_type == "pipelines":
+            raise UserWarning("Expanding a subworkflow from a class is not supported for pipelines.")
+
         if self.directory != ".":
             log.info(f"Base directory: '{self.directory}'")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-nf-core
+nf-core==3.0.*


### PR DESCRIPTION
Don't allow expanding a subworkflow in a pipelines repo & pin nf-core version