### PR TITLE
Remove prefix and suffix options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@
 - Handle composed modules when expanding a subworkflow [#6](https://github.com/mirpedrol/nf-class/pull/6)
 - Modify `expand-class` command to avoid conditional includes [#8](https://github.com/mirpedrol/nf-class/pull/8)
 - Don't allow expanding a subworkflow in a pipelines repo & pin nf-core version [#10](https://github.com/mirpedrol/nf-class/pull/10)
+- Remove `prefix` and `suffix` options from `expand-class` command [#11](https://github.com/mirpedrol/nf-class/pull/11)

--- a/README.md
+++ b/README.md
@@ -90,6 +90,4 @@ nf-class subworkflows expand-class <classname>
 - `--author` `-a`: Subworkflow author's GitHub username prefixed with '@'.
 - `--force` `-f`: Overwrite any files if they already exist.
 - `--expand-modules` `-m`: Name of the modules the subworkflow should expand, separated by commas. If not provided, all available modules for the class will be expanded.
-- `--prefix` `-p`: Prefix for the subworkflow name [<prefix>_classname_<suffix>].
-- `--suffix` `-s`: Suffix for the subworkflow name [<prefix>_classname_<suffix>].
 - `--help` `-h`: Show help message and exit.

--- a/nf_class/__main__.py
+++ b/nf_class/__main__.py
@@ -339,20 +339,6 @@ def subworkflows(ctx, git_remote, branch, no_pull):
     default=None,
     help="Name of the modules the subworkflow should expand, separated by commas. If not provided, all available modules for the class will be expanded.",
 )
-@click.option(
-    "-p",
-    "--prefix",
-    type=str,
-    default="",
-    help="Prefix for the subworkflow name [<prefix>_classname_<suffix>].",
-)
-@click.option(
-    "-s",
-    "--suffix",
-    type=str,
-    default="",
-    help="Suffix for the subworkflow name [<prefix>_classname_<suffix>].",
-)
 def command_subworkflows_expand_class(
     ctx,
     classname,
@@ -360,8 +346,6 @@ def command_subworkflows_expand_class(
     author,
     force,
     expand_modules,
-    prefix,
-    suffix,
 ):
     """
     Create a new DSL2 subworkflow from a class.
@@ -375,8 +359,6 @@ def command_subworkflows_expand_class(
             author,
             force,
             expand_modules,
-            prefix,
-            suffix,
             ctx.obj["modules_repo_url"],
             ctx.obj["modules_repo_branch"],
         )

--- a/nf_class/subworkflows/create.py
+++ b/nf_class/subworkflows/create.py
@@ -3,12 +3,10 @@ import re
 from pathlib import Path
 from typing import Optional
 
-import questionary
 import yaml
 
 from nf_class.components.create import ComponentCreateFromClass
 from nf_class.utils import NF_CLASS_MODULES_REMOTE
-from nf_core.utils import nfcore_question_style
 
 log = logging.getLogger(__name__)
 
@@ -23,8 +21,6 @@ class SubworkflowExpandClass(ComponentCreateFromClass):
         author (str): Author of the subworkflow.
         force (bool): Overwrite existing files.
         expand_modules (str): List of modules to expand the subworkflow with.
-        prefix (str): Prefix for the subworkflow name [<prefix>_classname_<suffix>].
-        suffix (str): Suffix for the subworkflow name [<prefix>_classname_<suffix>].
         modules_repo_url (str): URL of the modules repository.
         modules_repo_branch (str): Branch of the modules repository.
     """
@@ -36,29 +32,14 @@ class SubworkflowExpandClass(ComponentCreateFromClass):
         author: Optional[str] = None,
         force: bool = False,
         expand_modules: str = "",
-        prefix: str = "",
-        suffix: str = "",
         modules_repo_url: Optional[str] = NF_CLASS_MODULES_REMOTE,
         modules_repo_branch: Optional[str] = "main",
     ):
-        while prefix == "" and suffix == "":
-            log.info("Please provide a prefix or suffix for the subworkflow name.")
-            prefix = questionary.text(
-                "Prefix:",
-                default="",
-                style=nfcore_question_style,
-            ).unsafe_ask()
-            suffix = questionary.text(
-                "Suffix:",
-                default="",
-                style=nfcore_question_style,
-            ).unsafe_ask()
-        subworkflow_name = f"{prefix}{'_' if prefix else ''}{classname}{'_' if suffix else ''}{suffix}"
         super().__init__(
             "subworkflows",
             dir,
             classname,
-            subworkflow_name,
+            classname,
             author,
             force,
             None,

--- a/tests/test_subworkflows.py
+++ b/tests/test_subworkflows.py
@@ -39,15 +39,11 @@ class TestSubworkflows(unittest.TestCase):
         subworkflow_expand = nf_class.subworkflows.create.SubworkflowExpandClass(
             classname="alignment",
             dir=self.class_modules,
-            prefix="my",
-            suffix="test",
             author="@me",
         )
         subworkflow_expand.expand_class()
-        assert (self.class_modules / "subworkflows" / "mirpedrol" / "my_alignment_test" / "main.nf").is_file()
-        assert (
-            self.class_modules / "subworkflows" / "mirpedrol" / "my_alignment_test" / "tests" / "main.nf.test"
-        ).is_file()
+        assert (self.class_modules / "subworkflows" / "mirpedrol" / "alignment" / "main.nf").is_file()
+        assert (self.class_modules / "subworkflows" / "mirpedrol" / "alignment" / "tests" / "main.nf.test").is_file()
 
         # Check that all modules have been included
         included_modules = []
@@ -60,7 +56,7 @@ class TestSubworkflows(unittest.TestCase):
             "MAGUS_ALIGN",
             "TCOFFEE_ALIGN",
         ]
-        with open(self.class_modules / "subworkflows" / "mirpedrol" / "my_alignment_test" / "main.nf") as fh:
+        with open(self.class_modules / "subworkflows" / "mirpedrol" / "alignment" / "main.nf") as fh:
             for line in fh:
                 if line.lstrip().startswith("include"):
                     included_modules.append(line.split()[2])
@@ -74,21 +70,17 @@ class TestSubworkflows(unittest.TestCase):
         subworkflow_expand = nf_class.subworkflows.create.SubworkflowExpandClass(
             classname="alignment",
             dir=self.class_modules,
-            prefix="my",
-            suffix="test",
             author="@me",
             expand_modules="clustalo/align,famsa/align",
         )
         subworkflow_expand.expand_class()
-        assert (self.class_modules / "subworkflows" / "mirpedrol" / "my_alignment_test" / "main.nf").is_file()
-        assert (
-            self.class_modules / "subworkflows" / "mirpedrol" / "my_alignment_test" / "tests" / "main.nf.test"
-        ).is_file()
+        assert (self.class_modules / "subworkflows" / "mirpedrol" / "alignment" / "main.nf").is_file()
+        assert (self.class_modules / "subworkflows" / "mirpedrol" / "alignment" / "tests" / "main.nf.test").is_file()
 
         # Check that specified modules have been included
         included_modules = []
         should_have_modules = ["CLUSTALO_ALIGN", "FAMSA_ALIGN"]
-        with open(self.class_modules / "subworkflows" / "mirpedrol" / "my_alignment_test" / "main.nf") as fh:
+        with open(self.class_modules / "subworkflows" / "mirpedrol" / "alignment" / "main.nf") as fh:
             for line in fh:
                 if line.lstrip().startswith("include"):
                     included_modules.append(line.split()[2])


### PR DESCRIPTION
- Remove prefixes and suffixes, they are not needed now that we don’t use aliases. The class name should already have the right name with a prefix or suffix if required.
- The subworkflow will have the same name as the class.